### PR TITLE
#11 SSL support for StandardMongoClientService

### DIFF
--- a/nifi-standard-services/nifi-mongo-service-bundle/nifi-mongo-service/pom.xml
+++ b/nifi-standard-services/nifi-mongo-service-bundle/nifi-mongo-service/pom.xml
@@ -33,7 +33,16 @@
         </dependency>
         <dependency>
             <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-framework-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-processor-utils</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-ssl-context-service-api</artifactId>
         </dependency>
         <dependency>
             <groupId>com.asymmetrik.nifi</groupId>

--- a/nifi-standard-services/nifi-mongo-service-bundle/nifi-mongo-service/src/main/java/com/asymmetrik/nifi/services/mongo/StandardMongoClientService.java
+++ b/nifi-standard-services/nifi-mongo-service-bundle/nifi-mongo-service/src/main/java/com/asymmetrik/nifi/services/mongo/StandardMongoClientService.java
@@ -112,7 +112,7 @@ public class StandardMongoClientService extends AbstractControllerService implem
             .build();
 
     private static final List<PropertyDescriptor> properties = ImmutableList.of(
-            HOSTS, SSL_CONTEXT_SERVICE, AUTH_DATABASE, USERNAME, PASSWORD, MIN_POOL_SIZE, MAX_POOL_SIZE);
+            HOSTS, SSL_CONTEXT_SERVICE, CLIENT_AUTH, AUTH_DATABASE, USERNAME, PASSWORD, MIN_POOL_SIZE, MAX_POOL_SIZE);
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {

--- a/nifi-standard-services/nifi-mongo-service-bundle/nifi-mongo-service/src/main/java/com/asymmetrik/nifi/services/mongo/StandardMongoClientService.java
+++ b/nifi-standard-services/nifi-mongo-service-bundle/nifi-mongo-service/src/main/java/com/asymmetrik/nifi/services/mongo/StandardMongoClientService.java
@@ -6,9 +6,13 @@ import java.util.Collection;
 import java.util.List;
 import java.util.StringTokenizer;
 
+import javax.net.ssl.SSLContext;
+
+import org.apache.commons.lang3.StringUtils;
 import com.google.common.collect.ImmutableList;
 import com.mongodb.MongoClient;
 import com.mongodb.MongoClientOptions;
+import com.mongodb.MongoClientOptions.Builder;
 import com.mongodb.MongoCredential;
 import com.mongodb.ServerAddress;
 import com.mongodb.client.MongoIterable;
@@ -17,6 +21,7 @@ import org.apache.nifi.annotation.documentation.CapabilityDescription;
 import org.apache.nifi.annotation.documentation.Tags;
 import org.apache.nifi.annotation.lifecycle.OnDisabled;
 import org.apache.nifi.annotation.lifecycle.OnEnabled;
+import org.apache.nifi.authentication.exception.ProviderCreationException;
 import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.components.PropertyValue;
 import org.apache.nifi.components.ValidationContext;
@@ -26,6 +31,8 @@ import org.apache.nifi.controller.ConfigurationContext;
 import org.apache.nifi.processor.exception.ProcessException;
 import org.apache.nifi.processor.util.StandardValidators;
 import org.apache.nifi.reporting.InitializationException;
+import org.apache.nifi.security.util.SslContextFactory;
+import org.apache.nifi.ssl.SSLContextService;
 
 @Tags({"asymmetrik", "mongo", "database", "connection"})
 @CapabilityDescription("Provides Mongo Database Client Service.")
@@ -42,6 +49,26 @@ public class StandardMongoClientService extends AbstractControllerService implem
             .expressionLanguageSupported(true)
             .required(true)
             .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .build();
+
+    public static final PropertyDescriptor SSL_CONTEXT_SERVICE = new PropertyDescriptor.Builder()
+            .name("ssl-context-service")
+            .displayName("SSL Context Service")
+            .description("The SSL Context Service used to provide client certificate information for TLS/SSL "
+                    + "connections.")
+            .required(false)
+            .identifiesControllerService(SSLContextService.class)
+            .build();
+
+    public static final PropertyDescriptor CLIENT_AUTH = new PropertyDescriptor.Builder()
+            .name("ssl-client-auth")
+            .displayName("Client Auth")
+            .description("Client authentication policy when connecting to secure (TLS/SSL) cluster. "
+                    + "Possible values are REQUIRED, WANT, NONE. This property is only used when an SSL Context "
+                    + "has been defined and enabled.")
+            .required(false)
+            .allowableValues(SSLContextService.ClientAuth.values())
+            .defaultValue("REQUIRED")
             .build();
 
     public static final PropertyDescriptor MAX_POOL_SIZE = new PropertyDescriptor.Builder()
@@ -85,7 +112,7 @@ public class StandardMongoClientService extends AbstractControllerService implem
             .build();
 
     private static final List<PropertyDescriptor> properties = ImmutableList.of(
-            HOSTS, AUTH_DATABASE, USERNAME, PASSWORD, MIN_POOL_SIZE, MAX_POOL_SIZE);
+            HOSTS, SSL_CONTEXT_SERVICE, AUTH_DATABASE, USERNAME, PASSWORD, MIN_POOL_SIZE, MAX_POOL_SIZE);
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
@@ -95,12 +122,8 @@ public class StandardMongoClientService extends AbstractControllerService implem
     @OnEnabled
     public void onConfigured(final ConfigurationContext context) throws InitializationException {
         List<ServerAddress> addresses = parseServerAddresses(context.getProperty(HOSTS).evaluateAttributeExpressions().getValue());
-        int minConnectionsPerHost = context.getProperty(MIN_POOL_SIZE).isSet() ? context.getProperty(MIN_POOL_SIZE).asInteger() : 0;
-        int maxConnectionsPerHost = context.getProperty(MAX_POOL_SIZE).isSet() ? context.getProperty(MAX_POOL_SIZE).asInteger() : 100;
-        MongoClientOptions clientOptions = MongoClientOptions.builder()
-                .minConnectionsPerHost(minConnectionsPerHost)
-                .connectionsPerHost(maxConnectionsPerHost)
-                .build();
+
+        MongoClientOptions clientOptions = getClientOptions(context);
 
         PropertyValue username = context.getProperty(USERNAME);
         PropertyValue password = context.getProperty(PASSWORD);
@@ -173,5 +196,64 @@ public class StandardMongoClientService extends AbstractControllerService implem
             addresses.add(new ServerAddress(split[0], port));
         }
         return addresses;
+    }
+
+    /**
+     * Build and return the MongoClientOptions based on the input configuration
+     * @param context - configuration context
+     * @return options to use to create a Mongo client
+     */
+    protected MongoClientOptions getClientOptions(final ConfigurationContext context) {
+        int minConnectionsPerHost = context.getProperty(MIN_POOL_SIZE).isSet() ? context.getProperty(MIN_POOL_SIZE).asInteger() : 0;
+        int maxConnectionsPerHost = context.getProperty(MAX_POOL_SIZE).isSet() ? context.getProperty(MAX_POOL_SIZE).asInteger() : 100;
+
+        Builder builder = MongoClientOptions.builder()
+                .minConnectionsPerHost(minConnectionsPerHost)
+                .connectionsPerHost(maxConnectionsPerHost);
+
+        // Only add / set the SSL context if it was provided. Otherwise, use the default socket factory
+        SSLContext sslContext = getSslContext(context);
+        if(sslContext != null) {
+            /*
+             * Need to set socket factory after setting SSL Enabled.
+             * Setting or resetting sslEnabled will set the SocketFactory
+             * to SSLSocketFactory.getDefault() or SocketFactory.getDefault(), respectively
+             */
+            builder.sslEnabled(true)
+                .socketFactory(sslContext.getSocketFactory());
+        }
+
+        return builder.build();
+    }
+
+    /**
+     * Based on the input context for this service, returns either a valid SSL Context or null
+     * @param context - configuration context
+     * @return the instance of the SSL context to use for this Mongo client, or null if none was configured
+     */
+    protected SSLContext getSslContext(final ConfigurationContext context) {
+        // Set up the client for secure (SSL/TLS communications) if configured to do so
+        final SSLContextService sslService = context.getProperty(SSL_CONTEXT_SERVICE).asControllerService(SSLContextService.class);
+        final String rawClientAuth = context.getProperty(CLIENT_AUTH).getValue();
+        final SSLContext sslContext;
+
+        if (sslService != null) {
+            final SSLContextService.ClientAuth clientAuth;
+            if (StringUtils.isBlank(rawClientAuth)) {
+                clientAuth = SSLContextService.ClientAuth.REQUIRED;
+            } else {
+                try {
+                    clientAuth = SSLContextService.ClientAuth.valueOf(rawClientAuth);
+                } catch (final IllegalArgumentException iae) {
+                    throw new ProviderCreationException(String.format("Unrecognized client auth '%s'. Possible values are [%s]",
+                            rawClientAuth, StringUtils.join(SslContextFactory.ClientAuth.values(), ", ")));
+                }
+            }
+            sslContext = sslService.createSSLContext(clientAuth);
+        } else {
+            sslContext = null;
+        }
+
+        return sslContext;
     }
 }

--- a/nifi-standard-services/nifi-standard-services-api-nar/pom.xml
+++ b/nifi-standard-services/nifi-standard-services-api-nar/pom.xml
@@ -43,6 +43,12 @@
             <artifactId>nifi-mongo-service-api</artifactId>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-standard-services-api-nar</artifactId>
+            <version>${nifi.version}</version>
+            <type>nar</type>
+        </dependency>
     </dependencies>
 </project>
 

--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,17 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.nifi</groupId>
+                <artifactId>nifi-ssl-context-service</artifactId>
+                <version>${nifi.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.nifi</groupId>
+                <artifactId>nifi-ssl-context-service-nar</artifactId>
+                <version>${nifi.version}</version>
+                <type>nar</type>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-utils</artifactId>
                 <version>${nifi.version}</version>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,11 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.nifi</groupId>
+                <artifactId>nifi-framework-api</artifactId>
+                <version>${nifi.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-distributed-cache-protocol</artifactId>
                 <version>${nifi.version}</version>
             </dependency>


### PR DESCRIPTION
Adding configurations to allow the StandardMongoClientService to specify an SSL Context and whether ClientAuth should be required.