### PR TITLE
Fixing AbstractWriteMongoProcessor Ordered Write Options

### DIFF
--- a/nifi-standard-bundle/nifi-standard-processors/src/main/java/com/asymmetrik/nifi/processors/mongo/AbstractWriteMongoProcessor.java
+++ b/nifi-standard-bundle/nifi-standard-processors/src/main/java/com/asymmetrik/nifi/processors/mongo/AbstractWriteMongoProcessor.java
@@ -172,7 +172,7 @@ public abstract class AbstractWriteMongoProcessor extends AbstractMongoProcessor
         // mapping of array indices for flow file errors
         Map<Integer, BulkWriteError> writeErrors = new HashMap<>();
         try {
-            this.collection.bulkWrite(documentsToWrite);
+            this.collection.bulkWrite(documentsToWrite, this.writeOptions);
         } catch (MongoBulkWriteException e) {
             List<BulkWriteError> errors = e.getWriteErrors();
             for (BulkWriteError docError : errors) {


### PR DESCRIPTION
The abstract class was not properly using the writeOptions with the "ordered" configuration after a regression introduced in the last PR #mybad