### PR TITLE
[NARS-27] BUG FIX: CalculateVolumeStatistic ont honoring correlation

### DIFF
--- a/nifi-standard-bundle/nifi-standard-processors/src/main/java/com/asymmetrik/nifi/processors/stats/CalculateVolumeStatistics.java
+++ b/nifi-standard-bundle/nifi-standard-processors/src/main/java/com/asymmetrik/nifi/processors/stats/CalculateVolumeStatistics.java
@@ -2,8 +2,6 @@ package com.asymmetrik.nifi.processors.stats;
 
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicLong;
 
 import com.asymmetrik.nifi.processors.util.MomentAggregator;
 import com.google.common.collect.ImmutableList;
@@ -17,11 +15,9 @@ import org.apache.nifi.annotation.behavior.WritesAttributes;
 import org.apache.nifi.annotation.documentation.CapabilityDescription;
 import org.apache.nifi.annotation.documentation.Tags;
 import org.apache.nifi.annotation.lifecycle.OnScheduled;
-import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.flowfile.FlowFile;
 import org.apache.nifi.processor.ProcessContext;
 import org.apache.nifi.processor.ProcessorInitializationContext;
-import org.apache.nifi.processor.util.StandardValidators;
 
 @TriggerWhenEmpty
 @InputRequirement(InputRequirement.Requirement.INPUT_ALLOWED)
@@ -32,74 +28,35 @@ import org.apache.nifi.processor.util.StandardValidators;
         @WritesAttribute(attribute = "AbstractStatsProcessor.correlationKey"),
         @WritesAttribute(attribute = "CalculateVolumeStatistics.count"),
         @WritesAttribute(attribute = "CalculateVolumeStatistics.sum"),
-        @WritesAttribute(attribute = "CalculateVolumeStatistics.min"),
-        @WritesAttribute(attribute = "CalculateVolumeStatistics.max"),
-        @WritesAttribute(attribute = "CalculateVolumeStatistics.avg"),
-        @WritesAttribute(attribute = "CalculateVolumeStatistics.stdev"),
-        @WritesAttribute(attribute = "CalculateVolumeStatistics.units"),
         @WritesAttribute(attribute = "CalculateVolumeStatistics.timestamp")
 })
 public class CalculateVolumeStatistics extends AbstractStatsProcessor {
 
-    /**
-     * Property Descriptors
-     */
-    static final PropertyDescriptor BUCKET_INTERVAL = new PropertyDescriptor.Builder()
-            .name("Bucket Interval")
-            .description("Indicates how long to aggregate event counts before sending to the statistics calculator.")
-            .required(true)
-            .addValidator(StandardValidators.TIME_PERIOD_VALIDATOR)
-            .defaultValue("1 s")
-            .build();
-
-    private volatile long bucketIntervalMillis;
-    private AtomicLong lastBucketFullTime = new AtomicLong();
-    private AtomicLong count = new AtomicLong();
-
     @Override
     protected void init(ProcessorInitializationContext context) {
-        properties = ImmutableList.of(BUCKET_INTERVAL, CORRELATION_ATTR, REPORTING_INTERVAL, BATCH_SIZE);
+        properties = ImmutableList.of(CORRELATION_ATTR, REPORTING_INTERVAL, BATCH_SIZE);
     }
 
     @OnScheduled
     @Override
     public void onScheduled(final ProcessContext context) {
         super.onScheduled(context);
-        bucketIntervalMillis = context.getProperty(BUCKET_INTERVAL).asTimePeriod(TimeUnit.MILLISECONDS);
     }
 
     @Override
     protected void updateStats(FlowFile flowFile, MomentAggregator aggregator, long currentTimestamp) {
-        count.incrementAndGet();
-
-        // Add the number of flowfiles seen if the window time is exceeded, then reset the counter
-        if (currentTimestamp >= lastBucketFullTime.get() + bucketIntervalMillis) {
-            lastBucketFullTime.set(currentTimestamp);
-            aggregator.addValue(count.getAndSet(0L));
-        }
+        aggregator.addValue(1.0);
     }
 
     @Override
     protected Optional<Map<String, String>> buildStatAttributes(long currentTimestamp, MomentAggregator aggregator) {
         // emit stats only if there is data
         if (aggregator.getN() > 0) {
-            Double bucket = (double) bucketIntervalMillis;
-            Double min = 1000.0 * aggregator.getMin() / bucket;
-            Double max = 1000.0 * aggregator.getMax() / bucket;
-            Double avg = 1000.0 * aggregator.getMean() / bucket;
-            Double stdev = 1000.0 * aggregator.getStandardDeviation() / bucket;
-
             Map<String, String> attributes = new ImmutableMap.Builder<String, String>()
-                    .put("CalculateVolumeStatistics.count", Integer.toString(aggregator.getN()))
-                    .put("CalculateVolumeStatistics.sum", Integer.toString((int) aggregator.getSum()))
-                    .put("CalculateVolumeStatistics.min", Integer.toString(min.intValue()))
-                    .put("CalculateVolumeStatistics.max", Integer.toString(max.intValue()))
-                    .put("CalculateVolumeStatistics.avg", Integer.toString(avg.intValue()))
-                    .put("CalculateVolumeStatistics.stdev", stdev.toString())
+                    .put("CalculateVolumeStatistics.count", Long.toString(aggregator.getN()))
+                    .put("CalculateVolumeStatistics.sum", Long.toString((long) aggregator.getSum()))
                     .put("CalculateVolumeStatistics.timestamp", Long.toString(currentTimestamp))
-                    .put("CalculateVolumeStatistics.units", COUNT_PER_SECOND)
                     .build();
-
             return Optional.of(attributes);
 
         } else {

--- a/nifi-standard-bundle/nifi-standard-processors/src/test/java/com/asymmetrik/nifi/processors/stats/CalculateVolumeStatisticsTest.java
+++ b/nifi-standard-bundle/nifi-standard-processors/src/test/java/com/asymmetrik/nifi/processors/stats/CalculateVolumeStatisticsTest.java
@@ -18,7 +18,6 @@ public class CalculateVolumeStatisticsTest {
     @Before
     public void setup() {
         runner = TestRunners.newTestRunner(CalculateVolumeStatistics.class);
-        runner.setProperty(CalculateVolumeStatistics.BUCKET_INTERVAL, "1 s");
         runner.setProperty(AbstractStatsProcessor.REPORTING_INTERVAL, "1 s");
         runner.setProperty(AbstractStatsProcessor.BATCH_SIZE, "100");
         runner.assertValid();
@@ -50,9 +49,7 @@ public class CalculateVolumeStatisticsTest {
         assertEquals(0, flowFile.getSize());
         assertStatAttributesPresent(flowFile);
         assertEquals(1, Integer.parseInt(flowFile.getAttribute("CalculateVolumeStatistics.count")));
-        assertEquals(1, Integer.parseInt(flowFile.getAttribute("CalculateVolumeStatistics.min")));
-        assertEquals(1, Integer.parseInt(flowFile.getAttribute("CalculateVolumeStatistics.max")));
-        assertEquals(1, Integer.parseInt(flowFile.getAttribute("CalculateVolumeStatistics.avg")));
+        assertEquals(1, Integer.parseInt(flowFile.getAttribute("CalculateVolumeStatistics.sum")));
     }
 
     @Test
@@ -110,11 +107,6 @@ public class CalculateVolumeStatisticsTest {
     private void assertStatAttributesPresent(MockFlowFile f) {
         assertNotNull(Integer.parseInt(f.getAttribute("CalculateVolumeStatistics.count")));
         assertNotNull(Integer.parseInt(f.getAttribute("CalculateVolumeStatistics.sum")));
-        assertNotNull(Integer.parseInt(f.getAttribute("CalculateVolumeStatistics.min")));
-        assertNotNull(Integer.parseInt(f.getAttribute("CalculateVolumeStatistics.max")));
-        assertNotNull(Integer.parseInt(f.getAttribute("CalculateVolumeStatistics.avg")));
-        assertNotNull(Double.parseDouble(f.getAttribute("CalculateVolumeStatistics.stdev")));
         assertNotNull(Long.parseLong(f.getAttribute("CalculateVolumeStatistics.timestamp")));
-        assertEquals("Count/Second", f.getAttribute("CalculateVolumeStatistics.units"));
     }
 }


### PR DESCRIPTION
The abstract statistics aggregator classes uses a correlation attribute to enable aggregations to be correlated by a user-specified attribute key. This subclass was not honoring that property. NOTE: this is a breaking change from the previous version because the property bucket interval has been removed.  This version of the NARs will prevent a clustered NiFi from starting if an existing version of this NAR exists anywhere on the canvas.