### PR TITLE
AggregateMongo Processor

### DIFF
--- a/nifi-standard-bundle/nifi-standard-processors/src/main/java/com/asymmetrik/nifi/processors/elasticsearch/AbstractElasticsearchHttpProcessor.java
+++ b/nifi-standard-bundle/nifi-standard-processors/src/main/java/com/asymmetrik/nifi/processors/elasticsearch/AbstractElasticsearchHttpProcessor.java
@@ -1,5 +1,7 @@
 package com.asymmetrik.nifi.processors.elasticsearch;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import okhttp3.Credentials;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
@@ -14,8 +16,6 @@ import org.apache.nifi.processor.exception.ProcessException;
 import org.apache.nifi.processor.util.StandardValidators;
 import org.apache.nifi.ssl.SSLContextService;
 import org.apache.nifi.util.StringUtils;
-import org.codehaus.jackson.JsonNode;
-import org.codehaus.jackson.map.ObjectMapper;
 
 import javax.net.ssl.SSLContext;
 import java.io.IOException;

--- a/nifi-standard-bundle/nifi-standard-processors/src/main/java/com/asymmetrik/nifi/processors/elasticsearch/PutElasticsearchHttp.java
+++ b/nifi-standard-bundle/nifi-standard-processors/src/main/java/com/asymmetrik/nifi/processors/elasticsearch/PutElasticsearchHttp.java
@@ -1,5 +1,7 @@
 package com.asymmetrik.nifi.processors.elasticsearch;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import okhttp3.HttpUrl;
 import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
@@ -26,8 +28,6 @@ import org.apache.nifi.processor.Relationship;
 import org.apache.nifi.processor.exception.ProcessException;
 import org.apache.nifi.processor.util.StandardValidators;
 import org.apache.nifi.util.StringUtils;
-import org.codehaus.jackson.JsonNode;
-import org.codehaus.jackson.node.ArrayNode;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;

--- a/nifi-standard-bundle/nifi-standard-processors/src/main/java/com/asymmetrik/nifi/processors/mongo/AggregateMongo.java
+++ b/nifi-standard-bundle/nifi-standard-processors/src/main/java/com/asymmetrik/nifi/processors/mongo/AggregateMongo.java
@@ -1,0 +1,127 @@
+package com.asymmetrik.nifi.processors.mongo;
+
+import com.google.common.collect.Sets;
+import com.mongodb.Block;
+import com.mongodb.DBObject;
+import com.mongodb.client.AggregateIterable;
+import com.mongodb.util.JSON;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.nifi.annotation.behavior.SupportsBatching;
+import org.apache.nifi.annotation.documentation.CapabilityDescription;
+import org.apache.nifi.annotation.documentation.Tags;
+import org.apache.nifi.annotation.lifecycle.OnScheduled;
+import org.apache.nifi.components.PropertyDescriptor;
+import org.apache.nifi.components.PropertyValue;
+import org.apache.nifi.flowfile.FlowFile;
+import org.apache.nifi.processor.ProcessContext;
+import org.apache.nifi.processor.ProcessSession;
+import org.apache.nifi.processor.ProcessorInitializationContext;
+import org.apache.nifi.processor.Relationship;
+import org.apache.nifi.processor.exception.ProcessException;
+import org.apache.nifi.processor.util.StandardValidators;
+import org.bson.Document;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+@SupportsBatching
+@Tags({"asymmetrik", "mongo", "query", "aggregate"})
+@CapabilityDescription("Executes Mongo aggregation pipelines")
+public class AggregateMongo extends AbstractMongoProcessor {
+
+    public static final PropertyDescriptor AGGREGATION_PIPELINE = new PropertyDescriptor.Builder()
+            .name("aggregate-pipeline")
+            .displayName("Aggregation Pipeline")
+            .description("The aggregation pipeline to execute")
+            .expressionLanguageSupported(true)
+            .addValidator(StandardValidators.NON_BLANK_VALIDATOR)
+            .defaultValue("[]")
+            .required(true)
+            .build();
+
+    public static final PropertyDescriptor OUTPUT_COLLECTION = new PropertyDescriptor.Builder()
+            .name("output-collection")
+            .displayName("Output Collection")
+            .description("The collection to receive the output results")
+            .required(false)
+            .expressionLanguageSupported(true)
+            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .build();
+
+    private List<PropertyDescriptor> props = Arrays.asList(MongoProps.MONGO_SERVICE, MongoProps.DATABASE,
+            MongoProps.COLLECTION, MongoProps.BATCH_SIZE, MongoProps.WRITE_CONCERN,
+            AGGREGATION_PIPELINE, OUTPUT_COLLECTION);
+
+    protected static final Relationship REL_ORIGINAL = new Relationship.Builder()
+            .name("original")
+            .description("Aggregation pipelines that succeed will be routed to this relationship.")
+            .build();
+
+    private PropertyValue pipelineProperty;
+    private PropertyValue outputCollectionProperty;
+
+    @Override
+    protected void init(ProcessorInitializationContext context) {
+        properties = Collections.unmodifiableList(props);
+        relationships = Collections.unmodifiableSet(Sets.newHashSet(REL_SUCCESS, REL_FAILURE, REL_ORIGINAL));
+        clientId = getIdentifier();
+    }
+
+    @OnScheduled
+    public void onScheduled(final ProcessContext context) {
+        pipelineProperty = context.getProperty(AGGREGATION_PIPELINE);
+        outputCollectionProperty = context.getProperty(OUTPUT_COLLECTION);
+
+        createMongoConnection(context);
+        ensureIndexes(context, collection);
+    }
+
+    @Override
+    public void onTrigger(ProcessContext context, ProcessSession session) throws ProcessException {
+
+        FlowFile flowFile = session.get();
+        if(flowFile == null) {
+            session.remove(flowFile);
+        }
+
+        try {
+            String pipelineString = pipelineProperty.evaluateAttributeExpressions(flowFile).getValue();
+
+            List<DBObject> pipeline = (List<DBObject>) JSON.parse(pipelineString);
+            List<Document> stages = new ArrayList<>(pipeline.size());
+            for(DBObject p : pipeline) {
+                stages.add(new Document(p.toMap()));
+            }
+
+            String outputCollection = outputCollectionProperty.evaluateAttributeExpressions(flowFile).getValue();
+            boolean hasOutputCollection = StringUtils.isNotBlank(outputCollection);
+            if(hasOutputCollection) {
+                stages.add(new Document("$out", outputCollection));
+            }
+
+            Block<Document> transferBlock = document -> {
+                FlowFile ff = session.clone(flowFile);
+                ff = session.write(ff, outputStream -> IOUtils.write(document.toJson(), outputStream));
+                session.transfer(ff, REL_SUCCESS);
+            };
+
+            AggregateIterable<Document> agg = collection.aggregate(stages);
+            if(hasOutputCollection) {
+                agg.toCollection();
+            }
+            else {
+                agg.forEach(transferBlock);
+            }
+
+            session.transfer(flowFile, REL_ORIGINAL);
+
+        } catch (Exception ex) {
+            getLogger().error("Failed to run aggregation pipeline", ex);
+            session.transfer(flowFile, REL_FAILURE);
+        }
+
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <jzlib.version>1.1.3</jzlib.version>
         <metrics-core.version>2.2.0</metrics-core.version>
         <mockito-core.version>1.10.19</mockito-core.version>
-        <mongo-java-driver.version>3.0.2</mongo-java-driver.version>
+        <mongo-java-driver.version>3.6.3</mongo-java-driver.version>
         <phantomjsdriver.version>1.2.1</phantomjsdriver.version>
         <selenium-java.version>2.53.1</selenium-java.version>
         <slf4j-api.version>1.7.10</slf4j-api.version>

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <nifi.version>1.4.0</nifi.version>
+        <nifi.version>1.6.0</nifi.version>
 
         <commons-collections.version>3.2.1</commons-collections.version>
         <commons-io.version>2.4</commons-io.version>
@@ -49,7 +49,7 @@
         <jzlib.version>1.1.3</jzlib.version>
         <metrics-core.version>2.2.0</metrics-core.version>
         <mockito-core.version>1.10.19</mockito-core.version>
-        <mongo-java-driver.version>3.0.2</mongo-java-driver.version>
+        <mongo-java-driver.version>3.6.3</mongo-java-driver.version>
         <phantomjsdriver.version>1.2.1</phantomjsdriver.version>
         <selenium-java.version>2.53.1</selenium-java.version>
         <slf4j-api.version>1.7.10</slf4j-api.version>

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <jzlib.version>1.1.3</jzlib.version>
         <metrics-core.version>2.2.0</metrics-core.version>
         <mockito-core.version>1.10.19</mockito-core.version>
-        <mongo-java-driver.version>3.6.3</mongo-java-driver.version>
+        <mongo-java-driver.version>3.0.2</mongo-java-driver.version>
         <phantomjsdriver.version>1.2.1</phantomjsdriver.version>
         <selenium-java.version>2.53.1</selenium-java.version>
         <slf4j-api.version>1.7.10</slf4j-api.version>


### PR DESCRIPTION
This is branched from the `feature/nifi-1.6.0-upgrade` branch, so that should be merged before this.

The new AggregateMongo processor allows for a dynamic aggregation pipeline to output either to FlowFiles or directly to a collection via the `$out` pipeline stage. Support for `$out` and the use of the `StandardMongoClientService` are the primary differences to Apache NiFi's `RunMongoAggregation` processor.