### PR TITLE
Change IP Address Dimension to use EC2 Tag Name

### DIFF
--- a/nifi-asymmetrik-standard-bundle/nifi-asymmetrik-standard-reporting-tasks/pom.xml
+++ b/nifi-asymmetrik-standard-bundle/nifi-asymmetrik-standard-reporting-tasks/pom.xml
@@ -67,17 +67,14 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk</artifactId>
-            <version>1.11.327</version>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-core</artifactId>
-            <version>1.11.535</version>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-cloudwatch</artifactId>
-            <version>1.11.516</version>
         </dependency>
         <!-- TESTING -->
         <dependency>

--- a/nifi-asymmetrik-standard-bundle/nifi-asymmetrik-standard-reporting-tasks/pom.xml
+++ b/nifi-asymmetrik-standard-bundle/nifi-asymmetrik-standard-reporting-tasks/pom.xml
@@ -66,6 +66,11 @@
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk</artifactId>
+            <version>1.11.327</version>
+        </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-core</artifactId>
             <version>1.11.535</version>
         </dependency>

--- a/nifi-asymmetrik-standard-bundle/nifi-asymmetrik-standard-reporting-tasks/pom.xml
+++ b/nifi-asymmetrik-standard-bundle/nifi-asymmetrik-standard-reporting-tasks/pom.xml
@@ -66,6 +66,11 @@
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-core</artifactId>
+            <version>1.11.535</version>
+        </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-cloudwatch</artifactId>
             <version>1.11.516</version>
         </dependency>

--- a/nifi-asymmetrik-standard-bundle/nifi-asymmetrik-standard-reporting-tasks/pom.xml
+++ b/nifi-asymmetrik-standard-bundle/nifi-asymmetrik-standard-reporting-tasks/pom.xml
@@ -66,14 +66,6 @@
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-cloudwatch</artifactId>
         </dependency>
         <!-- TESTING -->

--- a/nifi-asymmetrik-standard-bundle/nifi-asymmetrik-standard-reporting-tasks/src/main/java/com/asymmetrik/nifi/models/SystemMetricsSnapshot.java
+++ b/nifi-asymmetrik-standard-bundle/nifi-asymmetrik-standard-reporting-tasks/src/main/java/com/asymmetrik/nifi/models/SystemMetricsSnapshot.java
@@ -8,7 +8,6 @@ import java.util.Map;
 
 public class SystemMetricsSnapshot {
     private String clusterNodeIdentifier;
-    private String hostname;
     private String ipAddress;
     private ProcessGroupStatusMetric rootProcessGroupSnapshot;
     private List<ConnectionStatusMetric> connectionSnapshots = new ArrayList<>();
@@ -32,13 +31,6 @@ public class SystemMetricsSnapshot {
 
     public String getIpAddress() {
         return ipAddress;
-    }
-
-    public String getHostname() { return hostname; }
-
-    public SystemMetricsSnapshot setHostname(String hostname) {
-        this.hostname= hostname;
-        return this;
     }
 
     public SystemMetricsSnapshot setIpAddress(String ipAddress) {

--- a/nifi-asymmetrik-standard-bundle/nifi-asymmetrik-standard-reporting-tasks/src/main/java/com/asymmetrik/nifi/models/SystemMetricsSnapshot.java
+++ b/nifi-asymmetrik-standard-bundle/nifi-asymmetrik-standard-reporting-tasks/src/main/java/com/asymmetrik/nifi/models/SystemMetricsSnapshot.java
@@ -8,6 +8,7 @@ import java.util.Map;
 
 public class SystemMetricsSnapshot {
     private String clusterNodeIdentifier;
+    private String hostname;
     private String ipAddress;
     private ProcessGroupStatusMetric rootProcessGroupSnapshot;
     private List<ConnectionStatusMetric> connectionSnapshots = new ArrayList<>();
@@ -31,6 +32,13 @@ public class SystemMetricsSnapshot {
 
     public String getIpAddress() {
         return ipAddress;
+    }
+
+    public String getHostname() { return hostname; }
+
+    public SystemMetricsSnapshot setHostname(String hostname) {
+        this.hostname= hostname;
+        return this;
     }
 
     public SystemMetricsSnapshot setIpAddress(String ipAddress) {

--- a/nifi-asymmetrik-standard-bundle/nifi-asymmetrik-standard-reporting-tasks/src/main/java/com/asymmetrik/nifi/reporting/AbstractNiFiClusterMetricsReporter.java
+++ b/nifi-asymmetrik-standard-bundle/nifi-asymmetrik-standard-reporting-tasks/src/main/java/com/asymmetrik/nifi/reporting/AbstractNiFiClusterMetricsReporter.java
@@ -118,7 +118,6 @@ abstract class AbstractNiFiClusterMetricsReporter extends AbstractReportingTask 
             .addValidator(Validator.VALID)
             .build();
 
-    private static final AmazonEC2 ec2 = AmazonEC2ClientBuilder.standard().build();
     private List<String> volumes;
     private List<String> processGroups;
     private List<String> remoteProcessGroups;
@@ -385,10 +384,11 @@ abstract class AbstractNiFiClusterMetricsReporter extends AbstractReportingTask 
     }
 
     public static String getHostname() {
+        AmazonEC2 ec2 = AmazonEC2ClientBuilder.standard().build();
 
         //Get the Instance information using the Instance ID
-        DescribeInstancesRequest request =  new DescribeInstancesRequest();
-                //.withInstanceIds(EC2MetadataUtils.getInstanceId());
+        DescribeInstancesRequest request =  new DescribeInstancesRequest()
+                .withInstanceIds(EC2MetadataUtils.getInstanceId());
 
         for(Tag tag : ec2.describeInstances(request)
                 .getReservations().get(0)

--- a/nifi-asymmetrik-standard-bundle/nifi-asymmetrik-standard-reporting-tasks/src/main/java/com/asymmetrik/nifi/reporting/AbstractNiFiClusterMetricsReporter.java
+++ b/nifi-asymmetrik-standard-bundle/nifi-asymmetrik-standard-reporting-tasks/src/main/java/com/asymmetrik/nifi/reporting/AbstractNiFiClusterMetricsReporter.java
@@ -387,8 +387,8 @@ abstract class AbstractNiFiClusterMetricsReporter extends AbstractReportingTask 
     public static String getHostname() {
 
         //Get the Instance information using the Instance ID
-        DescribeInstancesRequest request =  new DescribeInstancesRequest()
-                .withInstanceIds(EC2MetadataUtils.getInstanceId());
+        DescribeInstancesRequest request =  new DescribeInstancesRequest();
+                //.withInstanceIds(EC2MetadataUtils.getInstanceId());
 
         for(Tag tag : ec2.describeInstances(request)
                 .getReservations().get(0)

--- a/nifi-asymmetrik-standard-bundle/nifi-asymmetrik-standard-reporting-tasks/src/main/java/com/asymmetrik/nifi/reporting/AbstractNiFiClusterMetricsReporter.java
+++ b/nifi-asymmetrik-standard-bundle/nifi-asymmetrik-standard-reporting-tasks/src/main/java/com/asymmetrik/nifi/reporting/AbstractNiFiClusterMetricsReporter.java
@@ -117,7 +117,7 @@ abstract class AbstractNiFiClusterMetricsReporter extends AbstractReportingTask 
             .expressionLanguageSupported(ExpressionLanguageScope.VARIABLE_REGISTRY)
             .addValidator(Validator.VALID)
             .build();
-    static AmazonEC2 ec2 = AmazonEC2ClientBuilder.standard().build();
+    private static AmazonEC2 ec2 = AmazonEC2ClientBuilder.defaultClient();
 
 
     private List<String> volumes;

--- a/nifi-asymmetrik-standard-bundle/nifi-asymmetrik-standard-reporting-tasks/src/main/java/com/asymmetrik/nifi/reporting/AbstractNiFiClusterMetricsReporter.java
+++ b/nifi-asymmetrik-standard-bundle/nifi-asymmetrik-standard-reporting-tasks/src/main/java/com/asymmetrik/nifi/reporting/AbstractNiFiClusterMetricsReporter.java
@@ -117,8 +117,7 @@ abstract class AbstractNiFiClusterMetricsReporter extends AbstractReportingTask 
             .expressionLanguageSupported(ExpressionLanguageScope.VARIABLE_REGISTRY)
             .addValidator(Validator.VALID)
             .build();
-    private static AmazonEC2 ec2;
-
+    private AmazonEC2 ec2 = AmazonEC2ClientBuilder.standard().build();
 
     private List<String> volumes;
     private List<String> processGroups;
@@ -386,7 +385,6 @@ abstract class AbstractNiFiClusterMetricsReporter extends AbstractReportingTask 
     }
 
     public String getHostname() {
-        ec2 = AmazonEC2ClientBuilder.standard().build();
 
         //Get the Instance information using the Instance ID
         DescribeInstancesRequest request =  new DescribeInstancesRequest()

--- a/nifi-asymmetrik-standard-bundle/nifi-asymmetrik-standard-reporting-tasks/src/main/java/com/asymmetrik/nifi/reporting/AbstractNiFiClusterMetricsReporter.java
+++ b/nifi-asymmetrik-standard-bundle/nifi-asymmetrik-standard-reporting-tasks/src/main/java/com/asymmetrik/nifi/reporting/AbstractNiFiClusterMetricsReporter.java
@@ -117,7 +117,7 @@ abstract class AbstractNiFiClusterMetricsReporter extends AbstractReportingTask 
             .expressionLanguageSupported(ExpressionLanguageScope.VARIABLE_REGISTRY)
             .addValidator(Validator.VALID)
             .build();
-    private static AmazonEC2 ec2 = AmazonEC2ClientBuilder.defaultClient();
+    private static AmazonEC2 ec2;
 
 
     private List<String> volumes;
@@ -385,7 +385,8 @@ abstract class AbstractNiFiClusterMetricsReporter extends AbstractReportingTask 
         return metrics;
     }
 
-    public static String getHostname() {
+    public String getHostname() {
+        ec2 = AmazonEC2ClientBuilder.standard().build();
 
         //Get the Instance information using the Instance ID
         DescribeInstancesRequest request =  new DescribeInstancesRequest()

--- a/nifi-asymmetrik-standard-bundle/nifi-asymmetrik-standard-reporting-tasks/src/main/java/com/asymmetrik/nifi/reporting/AbstractNiFiClusterMetricsReporter.java
+++ b/nifi-asymmetrik-standard-bundle/nifi-asymmetrik-standard-reporting-tasks/src/main/java/com/asymmetrik/nifi/reporting/AbstractNiFiClusterMetricsReporter.java
@@ -21,12 +21,11 @@ import com.asymmetrik.nifi.models.SystemMetricsSnapshot;
 import com.asymmetrik.nifi.models.influxdb.MetricFields;
 import com.yammer.metrics.core.VirtualMachineMetrics;
 
+import com.amazonaws.util.EC2MetadataUtils;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.nifi.annotation.lifecycle.OnScheduled;
 import org.apache.nifi.components.PropertyDescriptor;
-import org.apache.nifi.components.ValidationContext;
-import org.apache.nifi.components.ValidationResult;
 import org.apache.nifi.components.Validator;
 import org.apache.nifi.controller.ConfigurationContext;
 import org.apache.nifi.controller.status.ConnectionStatus;
@@ -154,6 +153,7 @@ abstract class AbstractNiFiClusterMetricsReporter extends AbstractReportingTask 
 
             SystemMetricsSnapshot systemMetricsSnapshot = new SystemMetricsSnapshot()
                     .setClusterNodeIdentifier(context.getClusterNodeIdentifier())
+                    .setHostname(getHostname())
                     .setIpAddress(getIpAddress())
                     .setRootProcessGroupSnapshot(new ProcessGroupStatusMetric(eventAccess.getControllerStatus()))
                     .setMachineMemory(computeMachineMemory())
@@ -374,6 +374,13 @@ abstract class AbstractNiFiClusterMetricsReporter extends AbstractReportingTask 
         }
 
         return metrics;
+    }
+
+    public static String getHostname() {
+
+        EC2MetadataUtils.get
+        return EC2MetadataUtils.getInstanceId();
+
     }
 
     /**

--- a/nifi-asymmetrik-standard-bundle/nifi-asymmetrik-standard-reporting-tasks/src/main/java/com/asymmetrik/nifi/reporting/AbstractNiFiClusterMetricsReporter.java
+++ b/nifi-asymmetrik-standard-bundle/nifi-asymmetrik-standard-reporting-tasks/src/main/java/com/asymmetrik/nifi/reporting/AbstractNiFiClusterMetricsReporter.java
@@ -117,6 +117,8 @@ abstract class AbstractNiFiClusterMetricsReporter extends AbstractReportingTask 
             .expressionLanguageSupported(ExpressionLanguageScope.VARIABLE_REGISTRY)
             .addValidator(Validator.VALID)
             .build();
+    static AmazonEC2 ec2 = AmazonEC2ClientBuilder.standard().build();
+
 
     private List<String> volumes;
     private List<String> processGroups;
@@ -384,7 +386,6 @@ abstract class AbstractNiFiClusterMetricsReporter extends AbstractReportingTask 
     }
 
     public static String getHostname() {
-        AmazonEC2 ec2 = AmazonEC2ClientBuilder.standard().build();
 
         //Get the Instance information using the Instance ID
         DescribeInstancesRequest request =  new DescribeInstancesRequest()

--- a/nifi-asymmetrik-standard-bundle/nifi-asymmetrik-standard-reporting-tasks/src/main/java/com/asymmetrik/nifi/reporting/AbstractNiFiClusterMetricsReporter.java
+++ b/nifi-asymmetrik-standard-bundle/nifi-asymmetrik-standard-reporting-tasks/src/main/java/com/asymmetrik/nifi/reporting/AbstractNiFiClusterMetricsReporter.java
@@ -117,8 +117,7 @@ abstract class AbstractNiFiClusterMetricsReporter extends AbstractReportingTask 
             .expressionLanguageSupported(ExpressionLanguageScope.VARIABLE_REGISTRY)
             .addValidator(Validator.VALID)
             .build();
-    private AmazonEC2 ec2 = AmazonEC2ClientBuilder.standard().build();
-
+    private AmazonEC2 ec2;
     private List<String> volumes;
     private List<String> processGroups;
     private List<String> remoteProcessGroups;
@@ -151,6 +150,10 @@ abstract class AbstractNiFiClusterMetricsReporter extends AbstractReportingTask 
         collectAllConnections = !context.getProperty(CONNECTIONS).isSet();
         collectAllInputPorts = !context.getProperty(INPUT_PORTS).isSet();
         collectAllOutputPorts = !context.getProperty(OUTPUT_PORTS).isSet();
+
+        if(ec2 == null){
+            ec2 = AmazonEC2ClientBuilder.standard().build();
+        }
     }
 
     @Override

--- a/nifi-asymmetrik-standard-bundle/nifi-asymmetrik-standard-reporting-tasks/src/main/java/com/asymmetrik/nifi/reporting/AbstractNiFiClusterMetricsReporter.java
+++ b/nifi-asymmetrik-standard-bundle/nifi-asymmetrik-standard-reporting-tasks/src/main/java/com/asymmetrik/nifi/reporting/AbstractNiFiClusterMetricsReporter.java
@@ -12,6 +12,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
+import com.amazonaws.services.ec2.AmazonEC2Client;
 import com.amazonaws.util.EC2MetadataUtils;
 import com.amazonaws.services.ec2.model.DescribeInstancesRequest;
 import com.amazonaws.services.ec2.AmazonEC2;
@@ -117,6 +118,7 @@ abstract class AbstractNiFiClusterMetricsReporter extends AbstractReportingTask 
             .expressionLanguageSupported(ExpressionLanguageScope.VARIABLE_REGISTRY)
             .addValidator(Validator.VALID)
             .build();
+
     private AmazonEC2 ec2;
     private List<String> volumes;
     private List<String> processGroups;
@@ -151,9 +153,6 @@ abstract class AbstractNiFiClusterMetricsReporter extends AbstractReportingTask 
         collectAllInputPorts = !context.getProperty(INPUT_PORTS).isSet();
         collectAllOutputPorts = !context.getProperty(OUTPUT_PORTS).isSet();
 
-        if(ec2 == null){
-            ec2 = AmazonEC2ClientBuilder.standard().build();
-        }
     }
 
     @Override
@@ -388,7 +387,7 @@ abstract class AbstractNiFiClusterMetricsReporter extends AbstractReportingTask 
     }
 
     public String getHostname() {
-
+        ec2 = AmazonEC2ClientBuilder.standard().build();
         //Get the Instance information using the Instance ID
         DescribeInstancesRequest request =  new DescribeInstancesRequest()
                 .withInstanceIds(EC2MetadataUtils.getInstanceId());
@@ -405,4 +404,5 @@ abstract class AbstractNiFiClusterMetricsReporter extends AbstractReportingTask 
         return "";
 
     }
+
 }

--- a/nifi-asymmetrik-standard-bundle/nifi-asymmetrik-standard-reporting-tasks/src/main/java/com/asymmetrik/nifi/reporting/AbstractNiFiClusterMetricsReporter.java
+++ b/nifi-asymmetrik-standard-bundle/nifi-asymmetrik-standard-reporting-tasks/src/main/java/com/asymmetrik/nifi/reporting/AbstractNiFiClusterMetricsReporter.java
@@ -16,7 +16,6 @@ import com.amazonaws.services.ec2.AmazonEC2;
 import com.amazonaws.services.ec2.AmazonEC2ClientBuilder;
 import com.amazonaws.services.ec2.model.Tag;
 
-
 import com.asymmetrik.nifi.models.ConnectionStatusMetric;
 import com.asymmetrik.nifi.models.PortStatusMetric;
 import com.asymmetrik.nifi.models.ProcessGroupStatusMetric;
@@ -25,8 +24,6 @@ import com.asymmetrik.nifi.models.RemoteProcessGroupStatusMetric;
 import com.asymmetrik.nifi.models.SystemMetricsSnapshot;
 import com.asymmetrik.nifi.models.influxdb.MetricFields;
 import com.yammer.metrics.core.VirtualMachineMetrics;
-
-
 
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -149,7 +146,6 @@ abstract class AbstractNiFiClusterMetricsReporter extends AbstractReportingTask 
         collectAllConnections = !context.getProperty(CONNECTIONS).isSet();
         collectAllInputPorts = !context.getProperty(INPUT_PORTS).isSet();
         collectAllOutputPorts = !context.getProperty(OUTPUT_PORTS).isSet();
-
     }
 
     @Override
@@ -399,7 +395,5 @@ abstract class AbstractNiFiClusterMetricsReporter extends AbstractReportingTask 
             }
         }
         return "";
-
     }
-
 }

--- a/nifi-asymmetrik-standard-bundle/nifi-asymmetrik-standard-reporting-tasks/src/main/java/com/asymmetrik/nifi/reporting/AbstractNiFiClusterMetricsReporter.java
+++ b/nifi-asymmetrik-standard-bundle/nifi-asymmetrik-standard-reporting-tasks/src/main/java/com/asymmetrik/nifi/reporting/AbstractNiFiClusterMetricsReporter.java
@@ -1,8 +1,6 @@
 package com.asymmetrik.nifi.reporting;
 
 import java.io.File;
-import java.net.InetAddress;
-import java.net.UnknownHostException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -12,7 +10,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
-import com.amazonaws.services.ec2.AmazonEC2Client;
 import com.amazonaws.util.EC2MetadataUtils;
 import com.amazonaws.services.ec2.model.DescribeInstancesRequest;
 import com.amazonaws.services.ec2.AmazonEC2;

--- a/nifi-asymmetrik-standard-bundle/nifi-asymmetrik-standard-reporting-tasks/src/main/java/com/asymmetrik/nifi/reporting/CloudwatchNiFiClusterMetricsReporter.java
+++ b/nifi-asymmetrik-standard-bundle/nifi-asymmetrik-standard-reporting-tasks/src/main/java/com/asymmetrik/nifi/reporting/CloudwatchNiFiClusterMetricsReporter.java
@@ -7,7 +7,6 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
-import com.amazonaws.util.EC2MetadataUtils;
 import com.asymmetrik.nifi.models.SystemMetricsSnapshot;
 import com.google.common.collect.ImmutableList;
 

--- a/nifi-asymmetrik-standard-bundle/nifi-asymmetrik-standard-reporting-tasks/src/main/java/com/asymmetrik/nifi/reporting/CloudwatchNiFiClusterMetricsReporter.java
+++ b/nifi-asymmetrik-standard-bundle/nifi-asymmetrik-standard-reporting-tasks/src/main/java/com/asymmetrik/nifi/reporting/CloudwatchNiFiClusterMetricsReporter.java
@@ -104,7 +104,6 @@ public class CloudwatchNiFiClusterMetricsReporter extends AbstractNiFiClusterMet
             .build();
 
     private AmazonCloudWatch cloudWatch;
-    private String hostname;
     private String namespace;
     boolean collectsMemory;
     boolean collectsJVMMetrics;
@@ -164,14 +163,11 @@ public class CloudwatchNiFiClusterMetricsReporter extends AbstractNiFiClusterMet
 
         List<Dimension> dimensions = new ArrayList<>();
 
-        // IP Address is always included in the dimensions
-        dimensions.add(new Dimension()
-                .withName("Ip Address")
-                .withValue(snapshot.getIpAddress())
-        );
+        // Include the Host Name as a Dimension
 
+        //EC2 Host/Tag Name
         dimensions.add(new Dimension()
-                .withName("Instance Id")
+                .withName("Host Name")
                 .withValue(snapshot.getHostname())
         );
 

--- a/nifi-asymmetrik-standard-bundle/nifi-asymmetrik-standard-reporting-tasks/src/main/java/com/asymmetrik/nifi/reporting/CloudwatchNiFiClusterMetricsReporter.java
+++ b/nifi-asymmetrik-standard-bundle/nifi-asymmetrik-standard-reporting-tasks/src/main/java/com/asymmetrik/nifi/reporting/CloudwatchNiFiClusterMetricsReporter.java
@@ -124,7 +124,6 @@ public class CloudwatchNiFiClusterMetricsReporter extends AbstractNiFiClusterMet
         cloudWatch = AmazonCloudWatchClientBuilder.standard()
                 .withCredentials(getCredentials(context))
                 .build();
-        // hostname = EC2MetadataUtils.getInstanceId();
         dynamicDimensions = new ArrayList<>();
         context.getProperties().forEach((property, value) -> {
             // For each dynamic property, create a new dimension with that key/value pair

--- a/nifi-asymmetrik-standard-bundle/nifi-asymmetrik-standard-reporting-tasks/src/test/java/com/asymmetrik/nifi/reporting/TestCloudwatchNiFiClusterMetricsReporter.java
+++ b/nifi-asymmetrik-standard-bundle/nifi-asymmetrik-standard-reporting-tasks/src/test/java/com/asymmetrik/nifi/reporting/TestCloudwatchNiFiClusterMetricsReporter.java
@@ -9,6 +9,7 @@ import java.util.Map;
 
 import com.amazonaws.services.cloudwatch.model.Dimension;
 import com.amazonaws.services.cloudwatch.model.MetricDatum;
+import com.amazonaws.util.EC2MetadataUtils;
 import com.asymmetrik.nifi.models.ProcessGroupStatusMetric;
 import com.asymmetrik.nifi.models.SystemMetricsSnapshot;
 
@@ -91,7 +92,7 @@ public class TestCloudwatchNiFiClusterMetricsReporter {
                 .setProcessGroupSnapshots(Arrays.asList(processGroupStatusMetric));
 
         List<Dimension> dimensions = new ArrayList<>();
-        List<MetricDatum> cloudwatchMetrics = 
+        List<MetricDatum> cloudwatchMetrics =
                 metricsCloudwatchReporter.collectMeasurements(new Date(), metrics, dimensions);
 
         assertEquals(10, cloudwatchMetrics.size());

--- a/nifi-asymmetrik-standard-bundle/nifi-asymmetrik-standard-reporting-tasks/src/test/java/com/asymmetrik/nifi/reporting/TestCloudwatchNiFiClusterMetricsReporter.java
+++ b/nifi-asymmetrik-standard-bundle/nifi-asymmetrik-standard-reporting-tasks/src/test/java/com/asymmetrik/nifi/reporting/TestCloudwatchNiFiClusterMetricsReporter.java
@@ -9,7 +9,6 @@ import java.util.Map;
 
 import com.amazonaws.services.cloudwatch.model.Dimension;
 import com.amazonaws.services.cloudwatch.model.MetricDatum;
-import com.amazonaws.util.EC2MetadataUtils;
 import com.asymmetrik.nifi.models.ProcessGroupStatusMetric;
 import com.asymmetrik.nifi.models.SystemMetricsSnapshot;
 

--- a/pom.xml
+++ b/pom.xml
@@ -34,8 +34,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <nifi.version>1.9.0</nifi.version>
-        <aws-java-sdk.version>1.11.327</aws-java-sdk.version>
-        <aws-java-sdk-core.version>1.11.535</aws-java-sdk-core.version>
+
         <aws-java-sdk-cloudwatch.version>1.11.516</aws-java-sdk-cloudwatch.version>
 
 
@@ -183,16 +182,6 @@
                 <version>${project.version}</version>
             </dependency>
 
-            <dependency>
-                <groupId>com.amazonaws</groupId>
-                <artifactId>aws-java-sdk</artifactId>
-                <version>${aws-java-sdk.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.amazonaws</groupId>
-                <artifactId>aws-java-sdk-core</artifactId>
-                <version>${aws-java-sdk-core.version}</version>
-            </dependency>
             <dependency>
                 <groupId>com.amazonaws</groupId>
                 <artifactId>aws-java-sdk-cloudwatch</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,6 @@
 
         <aws-java-sdk-cloudwatch.version>1.11.516</aws-java-sdk-cloudwatch.version>
 
-
         <commons-collections.version>3.2.1</commons-collections.version>
         <commons-io.version>2.6</commons-io.version>
         <commons-lang3.version>3.8.1</commons-lang3.version>

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,10 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <nifi.version>1.9.0</nifi.version>
+        <aws-java-sdk.version>1.11.327</aws-java-sdk.version>
+        <aws-java-sdk-core.version>1.11.535</aws-java-sdk-core.version>
+        <aws-java-sdk-cloudwatch.version>1.11.516</aws-java-sdk-cloudwatch.version>
+
 
         <commons-collections.version>3.2.1</commons-collections.version>
         <commons-io.version>2.6</commons-io.version>
@@ -178,6 +182,23 @@
                 <artifactId>nifi-asymmetrik-mongo-service</artifactId>
                 <version>${project.version}</version>
             </dependency>
+
+            <dependency>
+                <groupId>com.amazonaws</groupId>
+                <artifactId>aws-java-sdk</artifactId>
+                <version>${aws-java-sdk.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.amazonaws</groupId>
+                <artifactId>aws-java-sdk-core</artifactId>
+                <version>${aws-java-sdk-core.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.amazonaws</groupId>
+                <artifactId>aws-java-sdk-cloudwatch</artifactId>
+                <version>${aws-java-sdk-cloudwatch.version}</version>
+            </dependency>
+
             <dependency>
                 <groupId>commons-collections</groupId>
                 <artifactId>commons-collections</artifactId>


### PR DESCRIPTION
Our CloudwatchReportingTask was previously utilizing the private IP for metric gathering (Grafana) and we want to change that to utilize the name of the instance itself (the EC2 Tag Name e.g. ostrich-dev-nifi-0)