### PR TITLE
Nifi 1.15.2 updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ nb-configuration.xml
 *.iws
 *~
 
+.vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ nb-configuration.xml
 .DS_Store
 .metadata
 .recommenders
+pom.xml.versionsBackup
 
 # Intellij
 .idea/

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,7 +7,7 @@ This project contains assorted [Apache NiFi](http://nifi.apache.org/) components
 
 # Requirements
 
-* Apache NiFi 1.15.2 or newer
+* Apache NiFi ${nifi.version} or newer
 * JDK 1.8 or newer
 * [Apache Maven](http://maven.apache.org/) 3.1.0 or newer
 
@@ -18,14 +18,14 @@ This project contains assorted [Apache NiFi](http://nifi.apache.org/) components
 $ mvn clean package
 ```
 
-This will create several .nar files, and collect them under `nifi-assembly/target/asymmetrik-nifi-nars-0.11.0-SNAPSHOT`. For convenience, this will also package all .nar files into a single distribution tar.gz file under `nifi-assembly/target/`.
+This will create several .nar files, and collect them under `nifi-assembly/target/asymmetrik-nifi-nars-${project.version}`. For convenience, this will also package all .nar files into a single distribution tar.gz file under `nifi-assembly/target/`.
 
 ```
 $ ls -1 nifi-assembly/target/asymmetrik-nifi-nars-*
-nifi-assembly/target/asymmetrik-nifi-nars-0.11.0-SNAPSHOT.tar.gz
+nifi-assembly/target/asymmetrik-nifi-nars-${project.version}.tar.gz
 
-nifi-assembly/target/asymmetrik-nifi-nars-0.11.0-SNAPSHOT:
-asymmetrik-nifi-nars-0.11.0-SNAPSHOT
+nifi-assembly/target/asymmetrik-nifi-nars-${project.version}:
+asymmetrik-nifi-nars-${project.version}
 ```
 ## Tests Dependencies
 
@@ -48,7 +48,7 @@ For example:
 
 ```
 nifi.nar.library.directory=./lib
-nifi.nar.library.directory.ext1=/path/to/asymm-nifi-nars/dist/target/asymmetrik-nifi-nars-0.11.0-SNAPSHOT/asymmetrik-nifi-nars-0.11.0-SNAPSHOT
+nifi.nar.library.directory.ext1=/path/to/asymm-nifi-nars/dist/target/asymmetrik-nifi-nars-${project.version}/asymmetrik-nifi-nars-${project.version}
 ```
 
 Then start NiFi as you normally would:

--- a/nifi-asymmetrik-standard-bundle/nifi-asymmetrik-standard-processors/src/main/java/com/asymmetrik/nifi/processors/AutoTerminator.java
+++ b/nifi-asymmetrik-standard-bundle/nifi-asymmetrik-standard-processors/src/main/java/com/asymmetrik/nifi/processors/AutoTerminator.java
@@ -73,7 +73,6 @@ public class AutoTerminator extends AbstractProcessor {
     @Override
     public void onTrigger(ProcessContext context, ProcessSession session) {
         session.remove(session.get(batchSize));
-        session.commit();
     }
 
     @Override

--- a/nifi-asymmetrik-standard-bundle/nifi-asymmetrik-standard-processors/src/main/java/com/asymmetrik/nifi/processors/elasticsearch/AbstractElasticsearchHttpProcessor.java
+++ b/nifi-asymmetrik-standard-bundle/nifi-asymmetrik-standard-processors/src/main/java/com/asymmetrik/nifi/processors/elasticsearch/AbstractElasticsearchHttpProcessor.java
@@ -25,6 +25,7 @@ import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.components.ValidationContext;
 import org.apache.nifi.components.ValidationResult;
@@ -34,7 +35,6 @@ import org.apache.nifi.processor.ProcessContext;
 import org.apache.nifi.processor.exception.ProcessException;
 import org.apache.nifi.processor.util.StandardValidators;
 import org.apache.nifi.ssl.SSLContextService;
-import org.apache.nifi.util.StringUtils;
 
 import javax.net.ssl.SSLContext;
 

--- a/nifi-asymmetrik-standard-bundle/nifi-asymmetrik-standard-processors/src/main/java/com/asymmetrik/nifi/processors/elasticsearch/AbstractElasticsearchProcessor.java
+++ b/nifi-asymmetrik-standard-bundle/nifi-asymmetrik-standard-processors/src/main/java/com/asymmetrik/nifi/processors/elasticsearch/AbstractElasticsearchProcessor.java
@@ -16,6 +16,7 @@
  */
 package com.asymmetrik.nifi.processors.elasticsearch;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.components.ValidationContext;
 import org.apache.nifi.components.ValidationResult;
@@ -25,7 +26,6 @@ import org.apache.nifi.processor.ProcessContext;
 import org.apache.nifi.processor.exception.ProcessException;
 import org.apache.nifi.processor.util.StandardValidators;
 import org.apache.nifi.ssl.SSLContextService;
-import org.apache.nifi.util.StringUtils;
 
 import java.util.Collection;
 import java.util.HashSet;

--- a/nifi-asymmetrik-standard-bundle/nifi-asymmetrik-standard-processors/src/main/java/com/asymmetrik/nifi/processors/elasticsearch/PutElasticsearchHttp.java
+++ b/nifi-asymmetrik-standard-bundle/nifi-asymmetrik-standard-processors/src/main/java/com/asymmetrik/nifi/processors/elasticsearch/PutElasticsearchHttp.java
@@ -27,6 +27,7 @@ import okhttp3.Response;
 import okhttp3.ResponseBody;
 
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.nifi.annotation.behavior.DynamicProperty;
 import org.apache.nifi.annotation.behavior.EventDriven;
 import org.apache.nifi.annotation.behavior.InputRequirement;
@@ -46,7 +47,6 @@ import org.apache.nifi.processor.ProcessSession;
 import org.apache.nifi.processor.Relationship;
 import org.apache.nifi.processor.exception.ProcessException;
 import org.apache.nifi.processor.util.StandardValidators;
-import org.apache.nifi.util.StringUtils;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;

--- a/nifi-asymmetrik-standard-bundle/nifi-asymmetrik-standard-reporting-tasks/src/main/java/com/asymmetrik/nifi/reporting/AbstractNiFiClusterMetricsReporter.java
+++ b/nifi-asymmetrik-standard-bundle/nifi-asymmetrik-standard-reporting-tasks/src/main/java/com/asymmetrik/nifi/reporting/AbstractNiFiClusterMetricsReporter.java
@@ -19,14 +19,13 @@ import com.asymmetrik.nifi.models.ProcessorStatusMetric;
 import com.asymmetrik.nifi.models.RemoteProcessGroupStatusMetric;
 import com.asymmetrik.nifi.models.SystemMetricsSnapshot;
 import com.asymmetrik.nifi.models.influxdb.MetricFields;
+import com.google.common.collect.ImmutableMap;
 import com.yammer.metrics.core.VirtualMachineMetrics;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.nifi.annotation.lifecycle.OnScheduled;
 import org.apache.nifi.components.PropertyDescriptor;
-import org.apache.nifi.components.ValidationContext;
-import org.apache.nifi.components.ValidationResult;
 import org.apache.nifi.components.Validator;
 import org.apache.nifi.controller.ConfigurationContext;
 import org.apache.nifi.controller.status.ConnectionStatus;
@@ -147,7 +146,7 @@ abstract class AbstractNiFiClusterMetricsReporter extends AbstractReportingTask 
 
     @Override
     public void onTrigger(final ReportingContext context) {
-        NiFiProperties nifiProperties = NiFiProperties.createBasicNiFiProperties(null, null);
+        NiFiProperties nifiProperties = NiFiProperties.createBasicNiFiProperties(null, ImmutableMap.of());
 
         try {
             EventAccess eventAccess = context.getEventAccess();

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <nifi.version>1.9.2</nifi.version>
+        <nifi.version>1.15.2</nifi.version>
 
         <awssdk.version>1.11.571</awssdk.version>
 
@@ -398,6 +398,34 @@
                     <scmBranchPropertyName>buildBranch</scmBranchPropertyName>
                 </configuration>
             </plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-resources-plugin</artifactId>
+				<version>3.0.1</version>
+				<executions>
+					<execution>
+						<id>readme-md</id>
+						<phase>process-resources</phase>
+						<goals>
+							<goal>copy-resources</goal>
+						</goals>
+						<configuration>
+							<outputDirectory>${project.basedir}</outputDirectory>
+							<resources>                                        
+								<resource>
+									<directory>${project.basedir}/docs</directory>
+									<includes>
+										<include>README.md</include>
+									</includes>
+									<filtering>true</filtering>
+								</resource>
+							</resources>
+							<encoding>UTF-8</encoding>
+						</configuration>            
+					</execution>
+				</executions>
+			</plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
I had to make some changes to the NAR files to get them to build for NiFi version 1.15.2, the only safe version of NiFi to run at this point(thanks Log4J). Below I'll list all the changes that I made, along with justifications:

Changes:
1. Removed an unnecessary `session.commit()` from `AutoTerminator.java` because that's done automatically at the end of execution of `onTrigger`, and `session.commit()` is deprecated.
2. Replaced `session.commit()` in `FetchFileSplits.java` with `session.commitAsync(callback)` because `session.commit()` is deprecated. This is easily the largest change in this PR, and I've never used that processor before, so it most likely needs verification.
3. Several instances of replacing `org.apache.nifi.util.StringUtils` with `org.apache.commons.lang3.StringUtils` since the former has been removed, and we include apache commons anyways
4. The `SSLContextService.ClientAuth` enum has been moved to its own file, so there's some changes removing the `SSLContextService` prefix to references of that enum
5. `PropertyDescriptor.expressionLanguageSupported(boolean)` is finally deprecated now, so there's a couple of changes for that
6. Since the minimum NiFi version was increased here but the readme hadn't been updated since NiFi version 1.3, I added templating to the README.md file. Now the versions get updated after every build, using maven variables for the template values. I've also committed the output of that templating as the new README.md.