### PR TITLE
Removed the AWS region dropdown so you can input non-standard regions

### DIFF
--- a/nifi-asymmetrik-standard-bundle/nifi-asymmetrik-standard-processors/src/main/java/com/asymmetrik/nifi/processors/aws/ListS3Batch.java
+++ b/nifi-asymmetrik-standard-bundle/nifi-asymmetrik-standard-processors/src/main/java/com/asymmetrik/nifi/processors/aws/ListS3Batch.java
@@ -162,6 +162,7 @@ public class ListS3Batch extends AbstractProcessor {
             .name("S3 Bucket AWS Region")
             .description("Determines which region that the S3 bucket is in. Default is us-east-1.")
             .defaultValue("us-east-1")
+						.expressionLanguageSupported(ExpressionLanguageScope.NONE)
             .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
             .required(true)
             .build();

--- a/nifi-asymmetrik-standard-bundle/nifi-asymmetrik-standard-processors/src/main/java/com/asymmetrik/nifi/processors/aws/ListS3Batch.java
+++ b/nifi-asymmetrik-standard-bundle/nifi-asymmetrik-standard-processors/src/main/java/com/asymmetrik/nifi/processors/aws/ListS3Batch.java
@@ -7,14 +7,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import javax.net.ssl.SSLContext;
 
 import com.amazonaws.ClientConfiguration;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.http.conn.ssl.SdkTLSSocketFactory;
-import com.amazonaws.regions.Regions;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.ListObjectsV2Request;
@@ -163,8 +161,8 @@ public class ListS3Batch extends AbstractProcessor {
     static final PropertyDescriptor AWS_REGION = new PropertyDescriptor.Builder()
             .name("S3 Bucket AWS Region")
             .description("Determines which region that the S3 bucket is in. Default is us-east-1.")
-            .allowableValues(getRegions())
             .defaultValue("us-east-1")
+            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
             .required(true)
             .build();
 
@@ -400,12 +398,6 @@ public class ListS3Batch extends AbstractProcessor {
         } catch (IOException ioe) {
             throw new ProcessException(ioe);
         }
-    }
-    
-    private static Set<String> getRegions() {
-        return Stream.of(Regions.values())
-                .map(Regions::getName)
-                .collect(Collectors.toSet());
     }
 
     private AWSCredentialsProvider getCredentials(final ProcessContext context) {

--- a/nifi-asymmetrik-standard-bundle/nifi-asymmetrik-standard-processors/src/main/java/com/asymmetrik/nifi/processors/aws/ListS3Batch.java
+++ b/nifi-asymmetrik-standard-bundle/nifi-asymmetrik-standard-processors/src/main/java/com/asymmetrik/nifi/processors/aws/ListS3Batch.java
@@ -162,7 +162,7 @@ public class ListS3Batch extends AbstractProcessor {
             .name("S3 Bucket AWS Region")
             .description("Determines which region that the S3 bucket is in. Default is us-east-1.")
             .defaultValue("us-east-1")
-						.expressionLanguageSupported(ExpressionLanguageScope.NONE)
+            .expressionLanguageSupported(ExpressionLanguageScope.NONE)
             .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
             .required(true)
             .build();


### PR DESCRIPTION
We needed to be able to input a region in the ListS3Batch that's not listed in the flatfile provided in the AWS SDK version that's used in this repo. This PR changes the dropdown list to a plain text field to allow this.